### PR TITLE
signup message issue solved

### DIFF
--- a/spec/features/signup_spec.rb
+++ b/spec/features/signup_spec.rb
@@ -1,16 +1,13 @@
 require 'rails_helper'
 
 describe 'the signup process', type: :feature do
-  before :each do
-    User.create(email: 'user1@gmail.com', password: 'password')
-  end
-  it 'signs @user in' do
+  it 'signs @user up' do
     visit '/users/sign_up'
     fill_in 'Email', with: 'user1@gmail.com'
     fill_in 'Password', with: 'password'
     fill_in 'Password confirmation', with: 'password'
     click_button 'Sign up'
-    expect(current_path).to eq(users_path)
-    #expect(page).to have_text('Welcome! You have signed up successfully.')
+    expect(current_path).to eq(root_path)
+    expect(page).to have_text('Welcome! You have signed up successfully.')
   end
 end


### PR DESCRIPTION
In the signup process, you don't need to create a user before that process, and the path that is expected after that process is your root. #2 